### PR TITLE
Generate task json route

### DIFF
--- a/backend/app/http_routes.py
+++ b/backend/app/http_routes.py
@@ -49,6 +49,7 @@ from routes.free_users_engagement import FreeUsersEngagementChecker
 from routes.retrieve_produced_text import RetrieveProducedText
 from routes.calendar_suggestion_notification import CalendarSuggestionNotifications
 from routes.home_chat import HomeChat
+from routes.task_json import TaskJson
 class HttpRouteManager:
     def __init__(self, api):
         api.add_resource(Purchase, '/purchase')
@@ -103,3 +104,4 @@ class HttpRouteManager:
         api.add_resource(RetrieveProducedText, "/retrieve_produced_text")
         api.add_resource(CalendarSuggestionNotifications, "/calendar_suggestion_notifications")
         api.add_resource(HomeChat, "/home_chat")
+        api.add_resource(TaskJson, "/task_json")

--- a/backend/app/routes/task.py
+++ b/backend/app/routes/task.py
@@ -51,7 +51,12 @@ class Task(Resource):
             # ensure output_type is in md_text_type
             output_type_pk = db.session.query(MdTextType.text_type_pk).filter(MdTextType.name == output_type).first()[0]
             if not output_type_pk:
-                return {"error": "unknown_text_type", "details": f"output_type must be in {db.session.query(MdTextType.name).all()}"}, 400
+                # add text_type to md_text_type
+                text_type = MdTextType(name=output_type)
+                db.session.add(text_type)
+                db.session.flush()
+                db.session.refresh(text_type)
+                output_type_pk = text_type.text_type_pk
 
             # ensure that display_data is a list
             if not isinstance(task_displayed_data, list):

--- a/backend/app/routes/task_json.py
+++ b/backend/app/routes/task_json.py
@@ -1,0 +1,72 @@
+import os
+from datetime import datetime
+
+from flask import request
+from flask_restful import Resource
+from app import db, log_error
+from db_models import MdTextType
+from models.llm_calls.mojodex_openai import MojodexOpenAI
+from azure_openai_conf import AzureOpenAIConf
+from jinja2 import Template
+from models.llm_calls.json_loader import json_decode_retry
+from app import on_json_error
+
+class TaskJson(Resource):
+
+    task_json_prompt = "/data/prompts/tasks/generate_json.txt"
+    task_json_generator = MojodexOpenAI(AzureOpenAIConf.azure_gpt4_turbo_conf, "GENERATE_TASK_JSON", AzureOpenAIConf.azure_gpt4_32_conf)
+
+    def __get_text_types(self):
+        try:
+            text_types = db.session.query(MdTextType.name).all()
+            return [text_type.name for text_type in text_types]
+        except Exception as e:
+            raise Exception(f"__get_text_types : {str(e)}")
+
+    @json_decode_retry(retries=3, required_keys=[], on_json_error=on_json_error)
+    def __generate_task_json(self, task_requirements, existing_text_types):
+        try:
+            with open(self.task_json_prompt, "r") as f:
+                template = Template(f.read())
+                prompt = template.render(task_requirements=task_requirements, existing_text_types=existing_text_types)
+
+            messages = [{"role": "system", "content": prompt}]
+
+            responses = self.task_json_generator.chat(messages, "backoffice", temperature=0, max_tokens=4000, json_format=True)
+
+            response = responses[0]
+            return response
+        except Exception as e:
+            raise Exception(f"__generate_task_json : {str(e)}")
+
+    # Route to create a new task json
+    # Route used only by Backoffice
+    # Protected by a secret
+    def post(self):
+        if not request.is_json:
+            return {"error": "Request must be JSON"}, 400
+
+        try:
+            secret = request.headers['Authorization']
+            if secret != os.environ["BACKOFFICE_SECRET"]:
+                return {"error": "Authentication error : Wrong secret"}, 403
+        except KeyError:
+            log_error(f"Error creating new task : Missing Authorization secret in headers")
+            return {"error": f"Missing Authorization secret in headers"}, 403
+        
+        try:
+            timestamp = request.json["datetime"]
+            task_requirements = request.json["task_requirements"]
+        except KeyError as e:
+            return {"error": f"Missing field {e}"}, 400
+        
+        try:
+            existing_text_types = self.__get_text_types()
+            task_json = self.__generate_task_json(task_requirements, existing_text_types)
+            task_json["datetime"] = datetime.now().isoformat()
+            task_json["predefined_actions"] = [] # TODO: Predefined actions are not in the prompt while not documented
+            return task_json, 200
+        except Exception as e:
+            log_error(f"Error creating new task : {str(e)}")
+            return {"error": f"Error creating new task : {str(e)}"}, 500
+

--- a/data/prompts/tasks/generate_json.txt
+++ b/data/prompts/tasks/generate_json.txt
@@ -1,0 +1,260 @@
+You are a json task expert writer.
+
+DOCUMENTATION TO WRITE A JSON TASK:
+
+create_new_task.json
+---
+# Create a new task
+
+## Technical definition
+A task is a JSON object that contains all necessary information to render it in the app and to guide the assistant through the process of drafting the document resulting from the task.
+You can find a template of a task in the file `task_spec.json` in this repository.
+
+Let's break this specification down with "meeting_minutes" task as an example.
+
+#### Platforms
+```
+"platforms": ["mobile"]
+```
+Platforms on which the task is available. Can be "webapp", "mobile" or both.
+
+### System information
+```
+"name_for_system": "prepare_meeting_minutes",
+"definition_for_system": "The user needs assistance to prepare a meeting minutes"
+```
+These fields are used by the system to defined tasks in prompts. name_for_system should be snake_case.
+
+### Final instruction
+```
+"final_instruction": "Write a meeting minutes in the form of bullet points"
+```
+This is the final instruction provided to the assistant prompt. It contains all instruction the assistant will follow to draft the document. It ends with an infinitive verb sentence as if it was an order to the assistant.
+
+### Output format
+```
+"output_format_instruction_title": "SHORT CONTEXT - DATE OF THE DAY",
+"output_format_instruction_draft": "CONTENT OF THE MEETING MINUTES"
+```
+These fields are used to define the format of the document resulting from the task. The assistant will use these instructions to format the document title and content.
+
+### Output type
+```
+"output_type": "meeting_minutes"
+```
+This field is used to define the type of document resulting from the task. It is used to enable special edition features once the document is ready. The value should match one existing in table 'md_text_type' of your database, if it does not, will be created.
+Existing md_text_type are {{existing_text_types}}. You can create a new one if none of these fits your needs.
+
+### Icon
+```
+"icon": "📝"
+```
+The icon displayed in the app to represent the task.
+
+### Task displayed data
+```
+"task_displayed_data": [
+    {
+        "language_code": "en",
+        "name_for_user": "Meeting Recap",
+        "definition_for_user": "Get a simple summary and next steps for your meeting",
+        "json_input": [
+            {
+                "input_name": "meeting_informations",
+                "description_for_user": "How was your meeting?",
+                "description_for_system": "Informations the user gave about the meeting (ex: participants, date, key topics, followup actions...)",
+                "placeholder": "Record a quick summary of what was discussed.",
+                "type": "text_area"
+            }
+        ]
+    },
+    {
+        "language_code": "fr",
+        "name_for_user": "Récapitulatif de Réunion",
+        "definition_for_user": "Obtenez un récapitulatif simple de votre réunion",
+        "json_input": [
+            {
+                "description_for_system": "Informations que l'utilisateur a fournies sur la réunion (ex : participants, date, sujets clés, actions de suivi...)",
+                "description_for_user": "Comment s'est passée votre réunion ?",
+                "input_name": "informations_reunion",
+                "placeholder": "Enregistrez un bref résumé de ce qui a été discuté.",
+                "type": "text_area"
+            }
+        ]
+    }
+]
+```
+This field contains all data displayed to the user in the app. It is an array of objects, each object representing a language. You can add as many languages as you want but you have to define at least english as it will be used as a fallback if the user's language is not available.
+The object contains the following fields:
+- language_code: the language code of the language
+- name_for_user: the name of the task in the language as it will be displayed to the user
+- definition_for_user: the definition of the task in the language as it will be displayed to the user
+- json_input: an array of objects, each object representing an information the user has to provide to the assistant when starting a new task.
+    - On the web app, it will be displayed as a form, one input per object.
+    - On the mobile app, it will be displayed in a chat as questions.
+    Each object contains the following fields:
+        - input_name: the name of the input as it will be used in the assistant prompt
+        - description_for_user: the description of the input as it will be displayed to the user
+        - description_for_system: the description of the input as it will be used in the assistant prompt
+        - placeholder: the placeholder of the input as it will be displayed to the user
+        - type: the type of the input. Can be only "text_area" for now.
+
+> Note: For mobile use to remain interface friendly, we recommend to keep the number of inputs to 1. If the assistant needs to ask more than one question, it will do it in a conversational way.
+
+### Infos to extract
+```
+"infos_to_extract": [
+    {
+        "info_name": "key_topics",
+        "description": "Key topics discussed in the meeting"
+    },
+    {
+        "info_name": "participants",
+        "description": "Participants of the meeting"
+    },
+    {
+        "info_name": "date_of_meeting",
+        "description": "Date of the meeting"
+    },
+    {
+        "info_name": "followup_actions",
+        "description": "Followup actions if any"
+    }
+]
+```
+This field contains all the information the assistant needs to collect from the user before drafting the document. It is an array of objects, each object representing an information. Each object contains the following fields:
+- info_name: the name of the information as it will be used in the assistant prompt
+- description: the description of the information as it will be used in the assistant prompt
+---
+
+EXAMPLES OF TASKS JSON:
+
+PREPARE_MEETING_MINUTES.json
+---
+{
+    "platforms": [
+        "mobile",
+        "webapp"
+    ],
+    "predefined_actions": [],
+    "task_displayed_data": [
+        {
+            "language_code": "en",
+            "name_for_user": "Meeting Recap",
+            "definition_for_user": "Prepare a detailed recap and next steps for your meeting",
+            "json_input": [
+                {
+                    "input_name": "meeting_informations",
+                    "description_for_user": "How was your meeting?",
+                    "description_for_system": "Informations the user gave about the meeting (ex: participants, date, key topics, followup actions...)",
+                    "placeholder": "Record a complete recap of what was discussed.",
+                    "type": "text_area"
+                }
+            ]
+        },
+        {
+            "language_code": "fr",
+            "name_for_user": "Récapitulatif de Réunion",
+            "definition_for_user": "Préparez un récapitulatif simple de votre réunion",
+            "json_input": [
+                {
+                    "description_for_system": "Informations que l'utilisateur a fournies sur la réunion (ex : participants, date, sujets clés, actions de suivi...)",
+                    "description_for_user": "Comment s'est passée votre réunion ?",
+                    "input_name": "informations_reunion",
+                    "placeholder": "Enregistrez un bref résumé de ce qui a été discuté.",
+                    "type": "text_area"
+                }
+            ]
+        }
+    ],
+    "name_for_system": "prepare_meeting_minutes",
+    "definition_for_system": "The user needs assistance to prepare a meeting minutes",
+    "final_instruction": "Write a well structured detailed meeting minutes including all the exhaustive informations provided by the user.",
+    "output_format_instruction_title": "SHORT CONTEXT - DATE OF THE DAY",
+    "output_format_instruction_draft": "CONTENT OF THE MEETING MINUTES",
+    "output_type": "meeting_minutes",
+    "icon": "📝",
+    "infos_to_extract": [
+        {
+            "info_name": "key_topics",
+            "description": "Key topics discussed in the meeting"
+        },
+        {
+            "info_name": "participants",
+            "description": "Participants of the meeting"
+        },
+        {
+            "info_name": "date_of_meeting",
+            "description": "Date of the meeting"
+        },
+        {
+            "info_name": "followup_actions",
+            "description": "Followup actions if any"
+        }
+    ]
+}
+---
+
+FOLLOW_UP_EMAIL.json
+---
+{
+    "datetime": "2024-02-14T10:53:06.502Z",
+    "platforms": [
+        "mobile",
+        "webapp"
+    ],
+    "predefined_actions": [],
+    "task_displayed_data": [
+        {
+            "language_code": "en",
+            "name_for_user": "Follow-up email",
+            "definition_for_user": "Get a preliminary follow-up email for your meeting",
+            "json_input": [
+                {
+                    "input_name": "meeting_informations",
+                    "description_for_user": "How was your meeting?",
+                    "description_for_system": "Informations the user gave about the meeting (ex: participants, date, key topics, followup actions...)",
+                    "placeholder": "Record a quick summary of what was discussed.",
+                    "type": "text_area"
+                }
+            ]
+        },
+        {
+            "language_code": "fr",
+            "name_for_user": "E-mail de suivi",
+            "definition_for_user": "Rédigez un e-mail suite à une réunion",
+            "json_input": [
+                {
+                    "description_for_system": "Informations que l'utilisateur a fournies sur la réunion (ex : participants, date, sujets clés, actions de suivi...)",
+                    "description_for_user": "Comment s'est passée votre réunion ?",
+                    "input_name": "informations_sur_la_reunion",
+                    "placeholder": "Enregistrez un rapide résumé de ce qui a été discuté.",
+                    "type": "text_area"
+                }
+            ]
+        }
+    ],
+    "name_for_system": "follow-up_email",
+    "definition_for_system": "The user needs assistance to prepare a follow-up email",
+    "final_instruction": "Write a follow-up email",
+    "output_format_instruction_title": "EMAIL SUBJECT",
+    "output_format_instruction_draft": "CONTENT OF THE EMAIL",
+    "output_type": "email",
+    "icon": "💌",
+    "infos_to_extract": [
+        {
+            "info_name": "meeting_notes",
+            "description": "The notes taken by the user about the meeting"
+        },
+        {
+            "info_name": "call_to_action",
+            "description": "The follow-up that the user expects from the meeting and wants to share if any"
+        }
+    ]
+}
+---
+
+
+Now, write the json body for a task with following requirements:
+{{task_requirements}}
+No talk, just well-formatted json.

--- a/docs/configure_assistant/sales_assistant_example/index.md
+++ b/docs/configure_assistant/sales_assistant_example/index.md
@@ -62,7 +62,15 @@ Now that we have a list of tasks, we want to design how Mojodex will facilitate 
 
 For each task, you now have a sentence that describes what the team is expecting the Sales Assistant to do.
 
-Use the following route to prepare a task in JSON format for each task: #TODO#
+Use the following route to prepare a task in JSON format for each task:
+```
+curl --location --request POST 'http://localhost:5001/task_json' \
+--header 'Authorization: backoffice_secret' \
+--header 'Content-Type: application/json' \
+--data-raw '{"datetime": "2024-02-14T17:49:26.545180",
+"task_requirements": "<task_description>"
+}'
+```
 
 You will need those JSON files for the next step: implementation
 

--- a/docs/configure_assistant/tasks/new_task.md
+++ b/docs/configure_assistant/tasks/new_task.md
@@ -36,7 +36,7 @@ These fields are used to define the format of the document resulting from the ta
 ```
 "output_type": "meeting_minutes"
 ```
-This field is used to define the type of document resulting from the task. It is used to enable special edition features once the document is ready. The value should match one existing in table 'md_text_type' of your database. Default existing values in database are "meeting_minutes", "email" and "document". You can add more types in the database if needed.
+This field is used to define the type of document resulting from the task. It is used to enable special edition features once the document is ready. The value should match one existing in table 'md_text_type' of your database, if it does not, will be created.
 
 ### Icon
 ```
@@ -137,17 +137,23 @@ STEP 1: Create the json file
 cp ./docs/configure_assistant/tasks/task_spec.json ./docs/configure_assistant/tasks/tasks_json/my_task.json
 ```
 
-Fill the json values of my_task.json with the ones fitting your need for this task.
+Fill the json values of my_task.json with the ones fitting your need for this task. 
+You can get helped by using the dedicated route so that GPT-4 generates a first json for you from your requirements.
+```
+curl --location --request POST 'http://localhost:5001/task_json' \
+--header 'Authorization: backoffice_secret' \
+--header 'Content-Type: application/json' \
+--data-raw '{"datetime": "2024-02-14T17:49:26.545180",
+"task_requirements": "You are the sales assistant of the user. The user needs help to (achieve/do/perform) [...]. The user needs this help in the following situation: [...]. You will need the following informations to proceed: [...]. The result of the task is a[{document_type}]"
+}'
+```
 
 STEP 2: Add the task to the database
 ```
-CURRENT_DATETIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-jq --arg datetime "$CURRENT_DATETIME" '. + {datetime: $datetime}' ./docs/configure_assistant/tasks/tasks_json/my_task.json > modified_task.json
-
 curl --location --request PUT 'http://localhost:5001/task' \
 --header 'Authorization: backoffice_secret' \
 --header 'Content-Type: application/json' \
---data @modified_task.json
+--data @my_task.json
 ```
 This command calls the backend REST API to create the task in the database and returns the primary key of the task. You will need this primary key in next step.
 

--- a/docs/configure_assistant/tasks/task_spec.json
+++ b/docs/configure_assistant/tasks/task_spec.json
@@ -1,4 +1,5 @@
 {
+    "datetime": "2024-02-14T17:49:26.545180",
     "platforms": ["webapp","mobile"],
     "predefined_actions": [],
     "task_displayed_data": [

--- a/docs/openAPI/backend_api.yaml
+++ b/docs/openAPI/backend_api.yaml
@@ -1564,6 +1564,100 @@ paths:
                 properties:
                   error:
                     type: string
+  /task_json:
+    post:
+      tags:
+        - Backoffice
+      summary: Generate json configuration file of a task from requirements description
+      parameters:
+        - in: header
+          name: Authorization
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - datetime
+                - task_requirements
+              properties:
+                datetime:
+                  type: string
+                  format: date-time
+                task_requirements:
+                  type: string
+      responses:
+        '200':
+          description: Task JSON created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  datetime:
+                    type: string
+                    format: date-time
+                  platforms:
+                    type: array
+                    items:
+                      type: string
+                  predefined_actions:
+                    type: array
+                    items:
+                      type: object
+                  task_displayed_data:
+                    type: array
+                    items:
+                      type: object
+                  name_for_system:
+                    type: string
+                  definition_for_system:
+                    type: string
+                  final_instruction:
+                    type: string
+                  output_format_instruction_title:
+                    type: string
+                  output_format_instruction_draft:
+                    type: string
+                  output_type:
+                    type: string
+                  icon:
+                    type: string
+                  infos_to_extract:
+                    type: array
+                    items:
+                      type: object
+        '400':
+          description: Bad request, missing fields or not a JSON request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        '403':
+          description: Authentication error, wrong or missing secret
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        '500':
+          description: Internal server error when creating new task
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
   /task_tool_query:
     put:
       tags:


### PR DESCRIPTION
Add a route to generate a json configuration file of a task from description of requirements

Edit task creation route to insert new  md_text_type on the go if output_type provided in json task does not exist yet for convenience Update related documentation:
- swagger
- sales assistant example
- create new task

I also added "datetime" field in task_spec.json and update associated documentation for convenience