### PR TITLE
Hubspot integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,7 +175,7 @@ EMBEDDING_API_TYPE=openai # or "azure"
 
 
 # Optional Hubspot configuration - If set, used to export data to Hubspot
-#HUBSPOT_API_KEY=
+#HUBSPOT_ACCESS_TOKEN=
 
 
 ############################################

--- a/.env.example
+++ b/.env.example
@@ -173,6 +173,11 @@ EMBEDDING_API_TYPE=openai # or "azure"
 #STRIPE_WEBHOOK_SECRET_END_PURCHASE=
 #STRIPE_WEBHOOK_SECRET_NEW_PURCHASE=
 
+
+# Optional Hubspot configuration - If set, used to export data to Hubspot
+#HUBSPOT_API_KEY=
+
+
 ############################################
 # TOOLS CONFIGURATION
 ############################################

--- a/backend/app/http_routes.py
+++ b/backend/app/http_routes.py
@@ -52,6 +52,7 @@ from routes.home_chat import HomeChat
 from routes.tool import Tool
 from routes.task_tool import TaskTool
 from routes.task_json import TaskJson
+from routes.export_to_hubspot import HubspotExport
 
 class HttpRouteManager:
     def __init__(self, api):
@@ -110,3 +111,4 @@ class HttpRouteManager:
         api.add_resource(Tool, "/tool")
         api.add_resource(TaskTool, "/task_tool")
         api.add_resource(TaskJson, "/task_json")
+        api.add_resource(HubspotExport, "/hubspot_export")

--- a/backend/app/http_routes.py
+++ b/backend/app/http_routes.py
@@ -52,7 +52,7 @@ from routes.home_chat import HomeChat
 from routes.tool import Tool
 from routes.task_tool import TaskTool
 from routes.task_json import TaskJson
-from routes.export_to_hubspot import HubspotExport
+from routes.integrations.hubspot import Hubspot
 
 class HttpRouteManager:
     def __init__(self, api):
@@ -111,4 +111,4 @@ class HttpRouteManager:
         api.add_resource(Tool, "/tool")
         api.add_resource(TaskTool, "/task_tool")
         api.add_resource(TaskJson, "/task_json")
-        api.add_resource(HubspotExport, "/hubspot_export")
+        api.add_resource(Hubspot, "/integrations/hubspot")

--- a/backend/app/routes/export_to_hubspot.py
+++ b/backend/app/routes/export_to_hubspot.py
@@ -1,0 +1,286 @@
+
+import pytz
+from flask import request
+from flask_restful import Resource
+from datetime import datetime, time
+from app import db, authenticate, log_error
+from db_models import MdProducedTextVersion, MdProducedText
+import requests
+import json
+import os
+
+class HubspotExport(Resource):
+   
+    def __init__(self):
+        HubspotExport.method_decorators = [authenticate()]
+
+    # From a produced_text_version_pk, suggests company, contact and deal to export to Hubspot and type of engagement
+    def post(self, user_id):
+        error_message = "Error in HubspotExport post method"
+        if not request.is_json:
+            log_error(f"{error_message} : Request must be JSON")
+            return {"error": "Request must be JSON"}, 400
+
+        # data
+        try:
+            timestamp = request.json["datetime"]
+            produced_text_version_pk = request.json["produced_text_version_pk"]
+        except KeyError as e:
+            log_error(f"{error_message} : Missing field {e}")
+            return {"error": f"Missing field {e}"}, 400
+        
+        try:
+            # check produced_text_version_pk exists for user_id
+            produced_text_version = db.session.query(MdProducedTextVersion)\
+                .join(MdProducedText, MdProducedTextVersion.produced_text_fk == MdProducedText.produced_text_pk)\
+                .filter(MdProducedText.user_id == user_id)\
+                .filter(MdProducedTextVersion.produced_text_version_pk == produced_text_version_pk)\
+                .first()
+            if not produced_text_version:
+                log_error(f"{error_message} : produced_text_version_pk {produced_text_version_pk} not found for user_id {user_id}")
+                return {"error": f"produced_text_version_pk {produced_text_version_pk} not found for user_id {user_id}"}, 400
+            
+            title, production = produced_text_version.title, produced_text_version.production
+
+            # TODO: catch proper nouns and search for them in Hubspot
+            # engagement is among ["Note", "Email", "Call", "Meetings"]
+            return {"company": None, "contact": None, "deal": None, "engagement": None}, 200
+        except Exception as e:
+            log_error(f"{error_message} : {str(e)}")
+            return {"error": str(e)}, 500
+
+
+    def __search_hubspot(self, search_object, properties, filterGroups):
+        try:
+            headers = {
+                'authorization': f"Bearer {os.environ['HUBSPOT_API_KEY']}",
+                'Content-Type': 'application/json'
+                }
+            url = f"https://api.hubapi.com/crm/v3/objects/{search_object}/search"
+
+            payload={
+                        "limit": 20,
+                        "properties": properties + ["id"],
+                        "filterGroups": filterGroups
+                    }
+            response = requests.request("POST", url, headers=headers, data=json.dumps(payload))
+
+            return response.json()["results"] # TODO: sometime "results" is null
+
+        except Exception as e:
+            raise Exception(f"__search_hubspot: {e}")
+            
+                  
+
+    # Search CRM company / contact or deal on the go from provided search string
+    def get(self, user_id):
+        error_message = "Error in HubspotExport get method"
+       
+        # data
+        try:
+            timestamp = request.args["datetime"]
+            search_type = request.args["search_type"]
+            # ensure search_type is among ["companies", "contacts", "deals"]
+            if search_type not in ["companies", "contacts", "deals"]:
+                log_error(f"{error_message} : search_type must be among ['companies', 'contacts', 'deals']")
+                return {"error": "search_type must be among ['companies', 'contacts', 'deals']"}, 400
+            search_string = request.args["search_string"]
+        except KeyError as e:
+            log_error(f"{error_message} : Missing field {e}")
+            return {"error": f"Missing field {e}"}, 400
+        
+        try:
+            
+            
+            if search_type == "companies":
+                properties = [ "name" ]
+                filtersGroup = [
+                            {
+                                "filters":[
+                                    {
+                                        "propertyName": "name",
+                                        "operator": "CONTAINS_TOKEN",
+                                        "value": f"{search_string}*"
+                                    }
+                                ]
+                            }
+                        ]
+                results = self.__search_hubspot(search_type, properties, filtersGroup)
+               
+                companies_list = [{"name": f"{result['properties']['name']}",
+                                 "id": result['id']} for result in results]
+                return {"results": companies_list}, 200
+
+            if search_type == "contacts":
+
+                properties = [ "firstname", "lastname", "email" ]
+                filtersGroup = [
+                            {
+                                "filters":[
+                                    {
+                                        "propertyName": "firstname",
+                                        "operator": "CONTAINS_TOKEN",
+                                        "value": f"{search_string}*"
+                                    }
+                                ]
+                            },
+                            {
+                                "filters":[
+                                {
+                                    "propertyName": "lastname",
+                                    "operator": "CONTAINS_TOKEN",
+                                    "value": f"{search_string}*"
+                                }
+                            ]
+                            }
+
+                        ]
+
+                results = self.__search_hubspot(search_type, properties, filtersGroup)
+
+                contacts_list = [{"name":f"{result['properties']['firstname']} {result['properties']['lastname']} - {result['properties']['email']}",
+                                 "id": result['id']} for result in results]
+
+                return {"results": contacts_list}, 200
+            
+            if search_type == "deals":
+
+                properties = [ "dealname" ]
+                filtersGroup = [
+                            {
+                                "filters":[
+                                    {
+                                        "propertyName": "dealname",
+                                        "operator": "CONTAINS_TOKEN",
+                                        "value": f"{search_string}*"
+                                    }
+                                ]
+                            }
+                        ]
+                
+                results = self.__search_hubspot(search_type, properties, filtersGroup)
+
+                deals_list = [{"name":f"{result['properties']['dealname']}",
+                               "id": result['id']} for result in results]
+                return {"results": deals_list}, 200
+            
+        except Exception as e:
+            log_error(f"{error_message} : {str(e)}", notify_admin=True)
+            return {"error": f"{error_message} : {str(e)}"}, 500
+
+    def __get_association_type_id(self, engagement_type, associated_object_type):
+        try:
+            url = f"https://api.hubapi.com/crm/v4/associations/{engagement_type}/{associated_object_type}/labels"
+    
+            headers = {
+            'authorization': f"Bearer {os.environ['HUBSPOT_API_KEY']}",
+            'Content-Type': 'application/json'
+            }
+
+            response = requests.request("GET", url, headers=headers)
+            return response.json()["results"][0]["typeId"]
+        except Exception as e:
+            raise Exception(f"__get_association_type_id: {e}")
+    
+
+
+    def __create_hubspot_engagement(self, engagement_type, associated_object_type, associated_object_id, text):
+        try:
+            association_type_id = self.__get_association_type_id(engagement_type, associated_object_type)
+
+            url = f"https://api.hubapi.com/crm/v3/objects/{engagement_type}"
+
+            headers = {
+            'authorization': f"Bearer {os.environ['HUBSPOT_API_KEY']}",
+            'Content-Type': 'application/json'
+            }
+
+            today_date = datetime.now().date()
+
+            # Create a datetime object for midnight
+            midnight_utc = datetime.combine(today_date, time(0, 0, 0), tzinfo=pytz.utc)
+
+
+            payload = {
+            "associations": [
+                {
+                "types": [
+                    {
+                    "associationCategory": "HUBSPOT_DEFINED",
+                    "associationTypeId": association_type_id
+                    }
+                ],
+                "to": {
+                    "id": associated_object_id
+                }
+                }
+            ],
+            "properties": {
+                "hs_note_body": text,
+                "hs_timestamp": midnight_utc.isoformat(),
+                #"hubspot_owner_id": "11349275740" => Facultative : TODO: check if a user could set it to its account parameter so that it is automatically set
+            }
+            }
+
+            payload = json.dumps(payload)
+
+
+            response = requests.request("POST", url, headers=headers, data=payload)
+
+            if response.status_code != 201:
+                raise Exception(f"__create_hubspot_engagement: {response.text}")
+
+        except Exception as e:
+            raise Exception(f"__create_hubspot_engagement: {e}")
+
+    # Route to send as an engagement to Hubspot
+    def put(self, user_id):
+        error_message = "Error in HubspotExport put method"
+        if not request.is_json:
+            log_error(f"{error_message} : Request must be JSON")
+            return {"error": "Request must be JSON"}, 400
+
+        # data
+        try:
+            timestamp = request.json["datetime"]
+            produced_text_version_pk = request.json["produced_text_version_pk"]
+            associated_object_id = request.json["associated_object_id"]
+            associated_object_type = request.json["associated_object_type"]
+            # ensure associated_object_type is among ['companies', 'contacts', 'deals']
+            if associated_object_type not in ['companies', 'contacts', 'deals']:
+                log_error(f"{error_message} : associated_object_type must be among ['companies', 'contacts', 'deals']")
+                return {"error": "associated_object_type must be among ['companies', 'contacts', 'deals']"}, 400
+            engagement_type = request.json["engagement_type"]
+            # ensure engagement_type is among["notes", "emails", "calls", "meetings"]
+            if engagement_type not in ["notes", "emails", "calls", "meetings"]:
+                log_error(f"{error_message} : engagement_type must be among ['notes', 'emails', 'calls', 'meetings']")
+                return {"error": "engagement_type must be among ['notes', 'emails', 'calls', 'meetings']"}, 400
+        except KeyError as e:
+            log_error(f"{error_message} : Missing field {e}")
+            return {"error": f"Missing field {e}"}, 400
+        
+        try:
+            # check produced_text_version_pk exists for user_id
+            produced_text_version = db.session.query(MdProducedTextVersion)\
+                .join(MdProducedText, MdProducedTextVersion.produced_text_fk == MdProducedText.produced_text_pk)\
+                .filter(MdProducedText.user_id == user_id)\
+                .filter(MdProducedTextVersion.produced_text_version_pk == produced_text_version_pk)\
+                .first()
+            if not produced_text_version:
+                log_error(f"{error_message} : produced_text_version_pk {produced_text_version_pk} not found for user_id {user_id}")
+                return {"error": f"produced_text_version_pk {produced_text_version_pk} not found for user_id {user_id}"}, 400
+            
+            title, production = produced_text_version.title, produced_text_version.production
+            text = f"{title}\n{production}"
+
+            
+            self.__create_hubspot_engagement(engagement_type, associated_object_type, associated_object_id, text)
+            return {"message": "Engagement sent to Hubspot"}, 200
+        except Exception as e:
+            log_error(f"{error_message} : {str(e)}")
+            return {"error": f"{error_message} : {str(e)}"}, 500
+
+
+
+
+            

--- a/backend/app/routes/export_to_hubspot.py
+++ b/backend/app/routes/export_to_hubspot.py
@@ -18,7 +18,7 @@ class HubspotExport(Resource):
     def __search_hubspot(self, search_object, properties, filterGroups):
         try:
             headers = {
-                'authorization': f"Bearer {os.environ['HUBSPOT_API_KEY']}",
+                'authorization': f"Bearer {os.environ['HUBSPOT_ACCESS_TOKEN']}",
                 'Content-Type': 'application/json'
                 }
             url = f"https://api.hubapi.com/crm/v3/objects/{search_object}/search"
@@ -138,7 +138,7 @@ class HubspotExport(Resource):
             url = f"https://api.hubapi.com/crm/v4/associations/{engagement_type}/{associated_object_type}/labels"
     
             headers = {
-            'authorization': f"Bearer {os.environ['HUBSPOT_API_KEY']}",
+            'authorization': f"Bearer {os.environ['HUBSPOT_ACCESS_TOKEN']}",
             'Content-Type': 'application/json'
             }
 
@@ -156,7 +156,7 @@ class HubspotExport(Resource):
             url = f"https://api.hubapi.com/crm/v3/objects/{engagement_type}"
 
             headers = {
-            'authorization': f"Bearer {os.environ['HUBSPOT_API_KEY']}",
+            'authorization': f"Bearer {os.environ['HUBSPOT_ACCESS_TOKEN']}",
             'Content-Type': 'application/json'
             }
 

--- a/backend/app/routes/integrations/hubspot.py
+++ b/backend/app/routes/integrations/hubspot.py
@@ -183,8 +183,7 @@ class Hubspot(Resource):
             ],
             "properties": {
                 "hs_note_body": text,
-                "hs_timestamp": midnight_utc.isoformat(),
-                #"hubspot_owner_id": "11349275740" => Facultative : TODO: check if a user could set it to its account parameter so that it is automatically set
+                "hs_timestamp": midnight_utc.isoformat()
             }
             }
 

--- a/data/languages/en.json
+++ b/data/languages/en.json
@@ -122,7 +122,11 @@
 			},
 			"editEmoji": "🎙️",
 			"editButton": "Edit",
-			"exportButton": "Export"
+			"exportButton": "Export",
+			"hubspotIntegration":{
+				"saveAs": "Save as ",
+				"in": " in "
+			}
 		},
 		"todosTab": {
 			"title": "Todos",

--- a/data/languages/es.json
+++ b/data/languages/es.json
@@ -122,7 +122,11 @@
             },
             "editEmoji": "🎙️",
             "editButton": "Editar",
-            "exportButton": "Exportar"
+            "exportButton": "Exportar",
+            "hubspotIntegration": {
+                "saveAs": "Guardar como ",
+                "in": " en "
+            }
         },
         "todosTab": {
             "title": "Pendientes",

--- a/data/languages/fr.json
+++ b/data/languages/fr.json
@@ -122,7 +122,11 @@
             },
             "editEmoji": "🎙️",
             "editButton": "Éditer",
-            "exportButton": "Exporter"
+            "exportButton": "Exporter",
+            "hubspotIntegration": {
+                "saveAs": "Enregistrer comme ",
+                "in": " dans "
+            }
         },
         "todosTab": {
             "title": "Todos",


### PR DESCRIPTION
Add some routes to export a task result to Hubspot:

- "GET" route to browse companies, contacts or deals to display to the user so that they can select which one to send to
- "PUT" route to export a task result as a note, call, email or meeting (engagement), associated with a company, contact or deal.

This feature requires to set a "HUBSPOT_ACCESS_TOKEN" value in .env file